### PR TITLE
Enable use_first_pass / force_first_pass support for PKCS

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -226,7 +226,7 @@ set_credential_options(struct pam_args *args, krb5_get_init_creds_opt *opts,
  * don't want them to.  We make the assumption here that the empty password is
  * always invalid and is an authentication failure.
  */
-static int
+int
 maybe_retrieve_password(struct pam_args *args, int authtok, const char **pass)
 {
     int status;

--- a/internal.h
+++ b/internal.h
@@ -90,6 +90,7 @@ struct pam_config {
     struct vector *preauth_opt; /* Preauth options. */
     bool try_pkinit;            /* Attempt PKINIT, fall back to password. */
     bool use_pkinit;            /* Require PKINIT. */
+    bool first_pass_is_pin;     /* Assume the cached password provided by PAM is a PIN */
 
     /* Prompting. */
     char *banner;               /* Addition to password changing prompts. */

--- a/options.c
+++ b/options.c
@@ -41,6 +41,7 @@ static const struct option options[] = {
     { K(expose_account),     true,  BOOL   (false) },
     { K(fail_pwchange),      true,  BOOL   (false) },
     { K(fast_ccache),        true,  STRING (NULL)  },
+    { K(first_pass_is_pin),  false, BOOL   (false) },
     { K(force_alt_auth),     true,  BOOL   (false) },
     { K(force_first_pass),   false, BOOL   (false) },
     { K(force_pwchange),     true,  BOOL   (false) },

--- a/pam_krb5.pod
+++ b/pam_krb5.pod
@@ -687,6 +687,12 @@ implementation instead.
 This option can be set in F<krb5.conf> and is only applicable to the auth
 and password groups.
 
+=item first_pass_is_pin
+
+[3.0] Assume any cached password provided by PAM is a PIN code.  This is
+useful to prevent multiple PIN entry prompts during login if the previous
+PAM module is known to cache the typed PIN.
+
 =back
 
 =head2 Prompting


### PR DESCRIPTION
Under certain PAM configurations, notably when pam_pkcs11 is
used as a backup offline authentication mechanism, the user
may be prompted multiple times for the card PIN.  If the
password / PIN is available from an earlier PAM module, and
the use_first_pass or force_first_pass options are set, return
that password / PIN to the Kerberos library without further
user prompting.