### PR TITLE
Don't query proxyable ticket on authentication

### DIFF
--- a/auth.c
+++ b/auth.c
@@ -153,6 +153,7 @@ set_credential_options(struct pam_args *args, krb5_get_init_creds_opt *opts,
 
     krb5_get_init_creds_opt_set_default_flags(c, "pam", args->realm, opts);
     if (!service) {
+        krb5_get_init_creds_opt_set_proxiable(opts, 0);
         if (config->forwardable)
             krb5_get_init_creds_opt_set_forwardable(opts, 1);
         if (config->ticket_lifetime != 0)


### PR DESCRIPTION
The given PAM stack:
```
auth     sufficient                         pam_krb5.so try_first_pass defer_pwchange
auth     required       pam_deny.so
account  required             pam_krb5.so force_pwchange
```
will result in PAM_AUTHTOK_ERR for authenticate() for a user (with krb5PasswordEnd set in the past) when contacting a heimdal KDC, which responds with KRB5KDC_ERR_POLICY -1765328372L and the string "Ticket may not be proxiable" if "proxiable = true" is defined in the
"[libdefaults]" section of /etc/krb5.conf.

The expected result would be PAM_SUCCESS in the authenticate() call and PAM_NEW_AUTHTOK_REQD in the acct_mgmt() call.

Setting the proxiable option to 0 solves this problem. I am not sure if it is anywhere else required. One could also add a new option like it's done for forwardable.