### PR TITLE
Add va_end() to early return from putil_log_failure

### DIFF
--- a/pam-util/logging.c
+++ b/pam-util/logging.c
@@ -255,8 +255,10 @@ putil_log_failure(struct pam_args *pargs, const char *fmt, ...)
         name = pargs->user;
     va_start(args, fmt);
     msg = format(fmt, args);
-    if (msg == NULL)
+    if (msg == NULL) {
+        va_end(args);
         return;
+    }
     va_end(args);
     pam_get_item(pargs->pamh, PAM_RUSER, (PAM_CONST void **) &ruser);
     pam_get_item(pargs->pamh, PAM_RHOST, (PAM_CONST void **) &rhost);


### PR DESCRIPTION
Noticed a possible issue with a missing va_end().