### PR TITLE
Add CI testing against a real Heimdal server

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -32,6 +32,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: install
         run: sudo ci/install
+      - name: kdc-setup-heimdal
+        run: sudo ci/kdc-setup-heimdal
+        if: matrix.kerberos == 'heimdal'
       - name: test
         run: ci/test
         env:

--- a/ci/files/heimdal/heimdal-kdc
+++ b/ci/files/heimdal/heimdal-kdc
@@ -1,0 +1,9 @@
+# Heimdal KDC init script setup.  -*- sh -*-
+
+# KDC configuration.
+KDC_ENABLED=yes
+KDC_PARAMS='--config-file=/etc/heimdal-kdc/kdc.conf'
+
+# kpasswdd configuration.
+KPASSWDD_ENABLED=yes
+KPASSWDD_PARAMS='-r HEIMDAL.TEST'

--- a/ci/files/heimdal/kadmind.acl
+++ b/ci/files/heimdal/kadmind.acl
@@ -1,0 +1,1 @@
+test/admin@HEIMDAL.TEST  all  testuser@HEIMDAL.TEST

--- a/ci/files/heimdal/kdc.conf
+++ b/ci/files/heimdal/kdc.conf
@@ -1,0 +1,30 @@
+# Heimdal KDC configuration.  -*- conf -*-
+
+[kadmin]
+    default_keys           = aes256-cts-hmac-sha1-96:pw-salt
+
+[kdc]
+    acl_file               = /etc/heimdal-kdc/kadmind.acl
+    check-ticket-addresses = false
+    logging                = SYSLOG:NOTICE
+    ports                  = 88
+
+    # PKINIT configuration.
+    enable-pkinit          = yes
+    pkinit_identity        = FILE:/etc/heimdal-kdc/kdc.pem
+    pkinit_anchors         = FILE:/etc/heimdal-kdc/ca/ca.pem
+    pkinit_mappings_file   = /etc/heimdal-kdc/pki-mapping
+    pkinit_allow_proxy_certificate  = no
+    pkinit_principal_in_certificate = no
+
+[libdefaults]
+    default_realm          = HEIMDAL.TEST
+    dns_lookup_kdc         = false
+    dns_lookup_realm       = false
+
+[realms]
+    HEIMDAL.TEST.EYRIE.ORG = {
+        kdc            = 127.0.0.1
+        master_kdc     = 127.0.0.1
+        admin_server   = 127.0.0.1
+    }

--- a/ci/files/heimdal/krb5.conf
+++ b/ci/files/heimdal/krb5.conf
@@ -1,0 +1,19 @@
+[libdefaults]
+    default_realm         = HEIMDAL.TEST
+    dns_lookup_kdc        = false
+    dns_lookup_realm      = false
+    rdns                  = false
+    renew_lifetime        = 7d
+    ticket_lifetime       = 25h
+
+[realms]
+    HEIMDAL.TEST = {
+        kdc               = 127.0.0.1
+        master_kdc        = 127.0.0.1
+        admin_server      = 127.0.0.1
+        pkinit_anchors    = FILE:/etc/heimdal-kdc/ca/ca.pem
+    }
+
+[logging]
+    kdc                   = SYSLOG:NOTICE
+    default               = SYSLOG:NOTICE

--- a/ci/files/heimdal/pki-mapping
+++ b/ci/files/heimdal/pki-mapping
@@ -1,0 +1,1 @@
+testuser@HEIMDAL.TEST:UID=testuser,DC=HEIMDAL,DC=TEST

--- a/ci/install
+++ b/ci/install
@@ -15,4 +15,4 @@ set -eux
 apt-get update -qq
 apt-get install aspell autoconf automake cppcheck heimdal-multidev      \
         krb5-config libkrb5-dev libpam0g-dev libtest-pod-perl           \
-        libtest-spelling-perl perl valgrind
+        libtest-spelling-perl libtool perl valgrind

--- a/ci/kdc-setup-heimdal
+++ b/ci/kdc-setup-heimdal
@@ -1,0 +1,105 @@
+#!/bin/sh
+#
+# Build a Kerberos test realm.
+#
+# This script automates the process of setting up a Kerberos test realm from
+# scratch suitable for testing pam-krb5.  It is primarily intended to be run
+# from inside CI in a VM or container from the top of the pam-krb5 source
+# tree, and must be run as root.  It expects to be operating on the Debian
+# Heimdal package.
+#
+# Copyright 2014, 2020 Russ Allbery <eagle@eyrie.org>
+#
+# SPDX-License-Identifier: MIT
+
+set -eux
+
+# Install the KDC.
+apt-get install heimdal-kdc
+
+# Install its configuration files.
+cp ci/files/heimdal/heimdal-kdc /etc/default/heimdal-kdc
+cp ci/files/heimdal/kadmind.acl /etc/heimdal-kdc/kadmind.acl
+cp ci/files/heimdal/kdc.conf /etc/heimdal-kdc/kdc.conf
+cp ci/files/heimdal/krb5.conf /etc/krb5.conf
+cp ci/files/heimdal/pki-mapping /etc/heimdal-kdc/pki-mapping
+
+# Some versions of heimdal-kdc require this.
+ln -s /etc/heimdal-kdc/kadmind.acl /var/lib/heimdal-kdc/kadmind.acl
+
+# Add domain-realm mappings for the local host, since otherwise Heimdal and
+# MIT Kerberos may attempt to discover the realm of the local domain, and the
+# DNS server for GitHub Actions has a habit of just not responding and causing
+# the test to hang.
+cat <<EOF >>/etc/krb5.conf
+[domain_realm]
+    $(hostname -f) = HEIMDAL.TEST
+EOF
+cat <<EOF >>/etc/heimdal-kdc/kdc.conf
+[domain_realm]
+    $(hostname -f) = HEIMDAL.TEST
+EOF
+
+# Create the basic KDC.
+kstash --random-key
+kadmin -l init --realm-max-ticket-life='1 day 1 hour' \
+    --realm-max-renewable-life='1 week' HEIMDAL.TEST
+
+# Set default principal policies.
+kadmin -l modify --attributes=requires-pre-auth,disallow-svr \
+    default@HEIMDAL.TEST
+
+# Create and store the keytabs.
+kadmin -l add -r --use-defaults --attributes=requires-pre-auth \
+    test/admin@HEIMDAL.TEST
+kadmin -l ext_keytab -k tests/config/admin-keytab test/admin@HEIMDAL.TEST
+kadmin -l add -r --use-defaults --attributes=requires-pre-auth \
+    test/keytab@HEIMDAL.TEST
+kadmin -l ext_keytab -k tests/config/keytab test/keytab@HEIMDAL.TEST
+
+# Create a user principal with a known password.
+password="iceedKaicVevjunwiwyd"
+kadmin -l add --use-defaults --password="$password" testuser@HEIMDAL.TEST
+echo 'testuser@HEIMDAL.TEST' >tests/config/password
+echo "$password" >>tests/config/password
+
+# Create the root CA for PKINIT.
+mkdir -p /etc/heimdal-kdc/ca
+hxtool issue-certificate --self-signed --issue-ca --generate-key=rsa    \
+    --subject=CN=CA,DC=HEIMDAL,DC=TEST --lifetime=10years               \
+    --certificate=FILE:/etc/heimdal-kdc/ca/ca.pem
+chmod 644 /etc/heimdal-kdc/ca/ca.pem
+
+# Create the certificate for the Heimdal Kerberos KDC.
+hxtool issue-certificate --ca-certificate=FILE:/etc/heimdal-kdc/ca/ca.pem \
+    --generate-key=rsa --type=pkinit-kdc                                  \
+    --pk-init-principal=krbtgt/HEIMDAL.TEST@HEIMDAL.TEST                  \
+    --subject=uid=kdc,DC=HEIMDAL,DC=TEST                                  \
+    --certificate=FILE:/etc/heimdal-kdc/kdc.pem
+chmod 644 /etc/heimdal-kdc/kdc.pem
+
+# Create the certificate for the Heimdal client.
+hxtool issue-certificate --ca-certificate=FILE:/etc/heimdal-kdc/ca/ca.pem \
+    --generate-key=rsa --type=pkinit-client                               \
+    --pk-init-principal=testuser@HEIMDAL.TEST                             \
+    --subject=UID=testuser,DC=HEIMDAL,DC=TEST                             \
+    --certificate=FILE:tests/config/pkinit-cert
+echo 'testuser@HEIMDAL.TEST' >tests/config/pkinit-principal
+
+# Fix permissions on all the newly-created files.
+chmod 644 tests/config/*
+
+# Restart the Heimdal KDC and services.
+systemctl stop heimdal-kdc
+systemctl start heimdal-kdc
+
+# Ensure that the KDC is running.
+for n in $(seq 1 5); do
+    if echo "$password" \
+            | kinit --password-file=STDIN testuser@HEIMDAL.TEST; then
+        break
+    fi
+    sleep 1
+done
+klist
+kdestroy

--- a/ci/test
+++ b/ci/test
@@ -26,6 +26,9 @@ else
 fi
 make warnings
 
+strace tests/runtests -o module/alt-auth
+exit 0
+
 # Run the regular tests with valgrind for one of the compilers.  Arbitrarily
 # pick the GCC build.  (The assumption here is that other compilers won't
 # produce sufficiently different code as to create memory management

--- a/tests/tap/kerberos.c
+++ b/tests/tap/kerberos.c
@@ -15,7 +15,7 @@
  * which can be found at <https://www.eyrie.org/~eagle/software/rra-c-util/>.
  *
  * Written by Russ Allbery <eagle@eyrie.org>
- * Copyright 2017 Russ Allbery <eagle@eyrie.org>
+ * Copyright 2017, 2020 Russ Allbery <eagle@eyrie.org>
  * Copyright 2006-2007, 2009-2014
  *     The Board of Trustees of the Leland Stanford Junior University
  *
@@ -293,6 +293,9 @@ kerberos_setup(enum kerberos_needs needs)
     char *path;
     char buffer[BUFSIZ];
     FILE *file = NULL;
+
+    /* Abort if the test takes too long to run. */
+    alarm(30);
 
     /* If we were called before, clean up after the previous run. */
     if (config != NULL)


### PR DESCRIPTION
When testing against Heimdal, automate setting up a Heimdal KDC in
the test VM and storing the necessary configuration to do full
Kerberos testing.