### PR TITLE
Add the require_fast option

### DIFF
--- a/docs/pam_krb5.pod
+++ b/docs/pam_krb5.pod
@@ -408,6 +408,12 @@ back on attempting anonymous PKINIT if that cache could not be used.
 This option can be set in C<[appdefaults]> in F<krb5.conf> and is only
 applicable to the auth and password groups.
 
+=item require_fast
+
+[4.12] Require use of FAST. If FAST is not available, this will cause the
+authentication to fail. This requires either anon_fast or fast_ccache (or
+both) to be set, otherwise the authentication will always fail.
+
 =item forwardable
 
 [1.0] Obtain forwardable tickets.  If set (to either true or false,

--- a/module/internal.h
+++ b/module/internal.h
@@ -66,6 +66,7 @@ struct pam_config {
     /* Kerberos behavior. */
     char *fast_ccache;           /* Cache containing armor ticket. */
     bool anon_fast;              /* sets up an anonymous fast armor cache */
+    bool require_fast;           /* Fail authentication without FAST */
     bool forwardable;            /* Obtain forwardable tickets. */
     char *keytab;                /* Keytab for credential validation. */
     char *realm;                 /* Default realm for Kerberos. */
@@ -216,7 +217,7 @@ krb5_error_code pamk5_alt_auth(struct pam_args *, const char *service,
 int pamk5_alt_auth_verify(struct pam_args *);
 
 /* FAST support.  Set up FAST protection of authentication. */
-void pamk5_fast_setup(struct pam_args *, krb5_get_init_creds_opt *);
+krb5_error_code pamk5_fast_setup(struct pam_args *, krb5_get_init_creds_opt *);
 
 /* Context management. */
 int pamk5_context_new(struct pam_args *);

--- a/module/options.c
+++ b/module/options.c
@@ -61,6 +61,7 @@ static const struct option options[] = {
     { K(realm),              false, STRING (NULL)  },
     { K(renew_lifetime),     true,  TIME   (0)     },
     { K(retain_after_close), true,  BOOL   (false) },
+    { K(require_fast),       true,  BOOL   (false) },
     { K(search_k5login),     true,  BOOL   (false) },
     { K(silent),             false, BOOL   (false) },
     { K(ticket_lifetime),    true,  TIME   (0)     },


### PR DESCRIPTION
Add the require_fast option which will cause the authentication to
fail if FAST is not available.

This is useful to prevent KDC reply spoofing and to prevent an attacker from intercepting the encrypted password hash and performing an offline attack on it (when SPAKE is not used).