### PR TITLE
Add ignore_groups option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ dnl Probe for the functionality of the PAM libraries and their include file
 dnl naming.  Mac OS X puts them in pam/* instead of security/*.
 AC_SEARCH_LIBS([pam_set_data], [pam])
 AC_CHECK_FUNCS([pam_getenv pam_getenvlist pam_modutil_getpwnam])
+AC_CHECK_FUNCS([pam_modutil_getgrnam getgrouplist])
 AC_REPLACE_FUNCS([pam_syslog pam_vsyslog])
 AC_CHECK_HEADERS([security/pam_modutil.h], [],
     [AC_CHECK_HEADERS([pam/pam_modutil.h])])

--- a/docs/pam_krb5.pod
+++ b/docs/pam_krb5.pod
@@ -293,6 +293,14 @@ want to use I<minimum_uid> instead.
 
 This option can be set in C<[appdefaults]> in F<krb5.conf>.
 
+=item ignore_groups
+
+[1.1] Do not do anything if the username is in any of the groups supplied
+in the comma delineated list.  This is mainly for cases where you have 
+users that need to be skipped that cannot be ignored by I<minimum_uid>.
+
+This option can be set in C<[appdefaults]> in F<krb5.conf>.
+
 =item minimum_uid=<uid>
 
 [2.0] Do not do anything if the authenticated account name corresponds to

--- a/module/internal.h
+++ b/module/internal.h
@@ -59,6 +59,7 @@ struct pam_config {
     bool force_alt_auth; /* Alt principal must be used if it exists. */
     bool ignore_k5login; /* Don't check .k5login files. */
     bool ignore_root;    /* Skip authentication for root. */
+    char *ignore_groups; /* Comma delineated list of groups of users to skip */
     long minimum_uid;    /* Ignore users below this UID. */
     bool only_alt_auth;  /* Alt principal must be used. */
     bool search_k5login; /* Try password with each line of .k5login. */

--- a/module/options.c
+++ b/module/options.c
@@ -46,6 +46,7 @@ static const struct option options[] = {
     { K(force_pwchange),     true,  BOOL   (false) },
     { K(forwardable),        true,  BOOL   (false) },
     { K(ignore_k5login),     true,  BOOL   (false) },
+    { K(ignore_groups),      true,  STRING (NULL)  },
     { K(ignore_root),        true,  BOOL   (false) },
     { K(keytab),             true,  STRING (NULL)  },
     { K(minimum_uid),        true,  NUMBER (0)     },

--- a/portable/pam.h
+++ b/portable/pam.h
@@ -113,6 +113,10 @@ BEGIN_DECLS
 #    define pam_modutil_getpwnam(h, u) getpwnam(u)
 #endif
 
+#if !HAVE_PAM_MODUTIL_GETGRNAM
+#    define pam_modutil_getgrnam(h, u) getgrnam(u)
+#endif
+
 /* Prototype missing optional PAM functions. */
 #if !HAVE_PAM_SYSLOG
 void pam_syslog(const pam_handle_t *, int, const char *, ...);


### PR DESCRIPTION
This adds the option 'ignore_groups' where a comma separated list of groups of users who should not be considered by pam_krb5 can be provided.

This was added to work around the lack of advanced conditional syntax in macOS where OpenPAM is used vs Linux-PAM.  Our specific use case is where pam_krb5 is used with FAST for OTP but there are non-OTP users present on the host.

minimum_uid doesn't help in these cases as these non-OTP users exist in a variety of uid ranges.  