### PR TITLE
suid_ccache option

### DIFF
--- a/docs/pam_krb5.pod
+++ b/docs/pam_krb5.pod
@@ -920,6 +920,16 @@ F</tmp>.
 This option can be set in C<[appdefaults]> in F<krb5.conf> and is only
 applicable to the auth and session groups.
 
+=item suid_ccache
+
+When creating final ccache, call seteuid. This helps creating caches in the
+proper location for C<KEYRING:persistent> cache types. Note that
+C<KEYRING:user> might not work (as it's deleted immediately), and
+C<KEYRING:session> can work without suid_ccache.
+
+This option might cause other issues, so sould be enabled with care and not by
+default.
+
 =back
 
 =head1 ENVIRONMENT

--- a/module/internal.h
+++ b/module/internal.h
@@ -106,6 +106,7 @@ struct pam_config {
     char *ccache_dir;        /* Directory for ticket cache. */
     bool no_ccache;          /* Don't create a ticket cache. */
     bool retain_after_close; /* Don't destroy the cache on session end. */
+    bool suid_ccache;        /* Call seteuid for final ccache creation. */
 
     /* The authentication context, which bundles together Kerberos data. */
     struct context *ctx;

--- a/module/options.c
+++ b/module/options.c
@@ -63,6 +63,7 @@ static const struct option options[] = {
     { K(retain_after_close), true,  BOOL   (false) },
     { K(search_k5login),     true,  BOOL   (false) },
     { K(silent),             false, BOOL   (false) },
+    { K(suid_ccache),        false, BOOL   (false) },
     { K(ticket_lifetime),    true,  TIME   (0)     },
     { K(trace),              false, STRING (NULL)  },
     { K(try_first_pass),     false, BOOL   (false) },

--- a/module/setcred.c
+++ b/module/setcred.c
@@ -417,7 +417,70 @@ pamk5_setcred(struct pam_args *args, bool refresh)
      * assumption that the default cache type is FILE; otherwise, due to the
      * type prefix, we'd end up with an invalid path.
      */
-    pamret = cache_init_from_cache(args, cache_name, ctx->cache, &cache);
+    if (args->config->suid_ccache && geteuid() != uid) {
+
+        /*
+         * to avoid messing with the temporary cache, as it needs to be
+         * readable after dropping uid, we create another temporary cache and
+         * use that.
+         */
+        const char *k5name = NULL;
+        char *suid_cache_name = NULL;
+        krb5_ccache suid_cache = NULL;
+        uid_t savedeuid = geteuid();
+
+        k5name = krb5_cc_get_name(ctx->context, ctx->cache);
+        if (k5name == NULL) {
+            putil_crit(args, "can't get name of temporary cache to copy");
+            pamret = PAM_SERVICE_ERR;
+            goto done;
+        }
+        status = asprintf(&suid_cache_name, "%s.suid", k5name);
+        if (status < 0) {
+            putil_crit(args, "malloc failure: %s", strerror(errno));
+            pamret = PAM_BUF_ERR;
+            goto done;
+        }
+
+        /* create a temprary suid file cache */
+        pamret = cache_init_from_cache(args, suid_cache_name, ctx->cache, &suid_cache);
+        if (pamret != PAM_SUCCESS) {
+            free(suid_cache_name);
+            goto done;
+        }
+
+        status = chown(suid_cache_name, uid, gid);
+        if (status == -1) {
+            putil_crit(args, "chown of temporary suid ticket cache failed: %s", strerror(errno));
+            krb5_cc_destroy(ctx->context, suid_cache);
+            free(suid_cache_name);
+            pamret = PAM_SERVICE_ERR;
+            goto done;
+        }
+
+        putil_debug(args, "setting euid to %i for cache creation", uid);
+        if (seteuid(uid) != 0) {
+            putil_notice(args, "can't seteuid for cache (%s), ignoring", strerror(errno));
+        }
+        putil_debug(args, "setting euid to %i for cache creation, we're now %i", uid, geteuid());
+
+        pamret = cache_init_from_cache(args, cache_name, suid_cache, &cache);
+
+        if (geteuid() != savedeuid) {
+            if (seteuid(savedeuid) != 0) {
+                putil_crit(args, "Can't seteuid back from %d: %s", geteuid(), strerror(errno));
+                krb5_cc_destroy(ctx->context, suid_cache);
+                free(suid_cache_name);
+                pamret = PAM_SERVICE_ERR;
+                goto done;
+            }
+        }
+
+        krb5_cc_destroy(ctx->context, suid_cache);
+        free(suid_cache_name);
+    } else {
+        pamret = cache_init_from_cache(args, cache_name, ctx->cache, &cache);
+    }
     if (pamret != PAM_SUCCESS)
         goto done;
     if (strncmp(cache_name, "FILE:", strlen("FILE:")) == 0)


### PR DESCRIPTION
When create the credential cache requires to be with the proper uid (e.g. with KEYRING:persistent), this causes the module to seteuid before creating the final cache.